### PR TITLE
use environment variable to config streams

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,11 @@
+//
+//
+// Copyright (C) 2016 Zalando SE
+//
+// This software may be modified and distributed under the terms
+// of the MIT license.  See the LICENSE file for details.
+//
+
 akka {
   loglevel = "DEBUG"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
@@ -21,21 +29,12 @@ akka {
 //    }
 //  }
 
-
-
   defaultAskTimeout = 15 s
 }
 
-##
-##
-## Copyright (C) 2016 Zalando SE
-##
-## This software may be modified and distributed under the terms
-## of the MIT license.  See the LICENSE file for details.
-##
 
 
-## "org.zalando.stups" % "tokens"
+// "org.zalando.stups" % "tokens"
 tokens {
   accessToken = "https://token.services.auth.zalando.com/oauth2/access_token?realm=/services"
   tokenInfo = "https://info.services.auth.zalando.com/oauth2/tokeninfo"
@@ -51,6 +50,9 @@ http {
 
 persistence {
   snapshotInitTimeout = 5 m
+
+  workingDirectory = "_work"
+  snapshotsDirectory = "_snapshots"
 }
 
 supervision {
@@ -58,4 +60,11 @@ supervision {
     maxFailures = 3
     period = 1 minute
   }
+}
+
+znap {
+  // `|` pipe separated list of data sources
+  // each data source is specified as URI
+  // https+nakadi://localhost:8080/eventstream
+  streams = ${?ZNAP_STREAMS}
 }

--- a/src/main/scala/org/zalando/znap/Main.scala
+++ b/src/main/scala/org/zalando/znap/Main.scala
@@ -13,9 +13,7 @@ import org.slf4j.LoggerFactory
 import org.zalando.znap.config.{Config, NakadiTarget}
 
 object Main extends App {
-  // TODO normal command line options processing
-  val snapshotsConfigFile = args(0)
-  val config = new Config(snapshotsConfigFile)
+  val config = new Config()
 
   val logger = LoggerFactory.getLogger(Main.getClass)
   logger.info(s"Application instance started with ID ${config.ApplicationInstanceId}")

--- a/src/main/scala/org/zalando/znap/config/ConfigStream.scala
+++ b/src/main/scala/org/zalando/znap/config/ConfigStream.scala
@@ -1,0 +1,38 @@
+package org.zalando.znap.config
+
+/** Config Stream : identity of stream end-point
+  *
+  */
+case class ConfigStream(
+  /** stream protocol e.g. nakadi */
+  schema: String,
+  protocol: String,
+
+  /** event stream authority */
+  host: String,
+  port: Int,
+
+  /** event stream id */
+  stream: String
+)
+
+object ConfigStream {
+
+  def apply(x: String): ConfigStream = {
+    val uri = new java.net.URI(x)
+    val Array(schema, protocol) = uri.getScheme.split('+')
+    val host = uri.getHost
+    val port = uri.getPort
+    val suid = uri.getPath.substring(1)
+
+    ConfigStream(schema, protocol, host, resolvePort(schema, port), suid)
+  }
+
+  def resolvePort(schema: String, port: Int) =
+    port match {
+      case -1 if schema.equals("http")  => 80
+      case -1 if schema.equals("https") => 443
+      case _ => port
+    }
+}
+

--- a/src/main/scala/org/zalando/znap/config/SnapshotTarget.scala
+++ b/src/main/scala/org/zalando/znap/config/SnapshotTarget.scala
@@ -11,9 +11,12 @@ trait SnapshotTarget {
   val id: String
 }
 
-final case class NakadiTarget(host: String,
-                        port: Int,
-                        secureConnection: Boolean,
-                        eventType: String) extends SnapshotTarget {
+// TODO: name eventType is confusing, this is name of stream
+// TODO: think to replace with ConfigStream
+final case class NakadiTarget(
+  schema: String,
+  host: String,
+  port: Int,
+  eventType: String) extends SnapshotTarget {
   override val id: String = eventType
 }

--- a/src/main/scala/org/zalando/znap/nakadi/GetPartitionsWorker.scala
+++ b/src/main/scala/org/zalando/znap/nakadi/GetPartitionsWorker.scala
@@ -42,12 +42,7 @@ class GetPartitionsWorker(nakadiTarget: NakadiTarget,
       val http = Http(context.system)
 
       // Request partitions of the topic.
-      val schema =
-      if (nakadiTarget.secureConnection) {
-        "https"
-      } else {
-        "http"
-      }
+      val schema = nakadiTarget.schema
       val uri = s"$schema://${nakadiTarget.host}/event-types/${nakadiTarget.eventType}/partitions"
       val authorizationHeader = new Authorization(OAuth2BearerToken(tokens.get()))
       val request = HttpRequest(

--- a/src/main/scala/org/zalando/znap/nakadi/NakadiReaderWorker.scala
+++ b/src/main/scala/org/zalando/znap/nakadi/NakadiReaderWorker.scala
@@ -43,7 +43,7 @@ class NakadiReaderWorker(partition: String,
     val headers = List(authorizationHeader, xNakadiCursor)
 
     val nakadiConnectionFlow =
-      if (target.secureConnection) {
+      if (target.schema.equals("https")) {
         Http(context.system).outgoingConnectionHttps(target.host, target.port)
       } else {
         Http(context.system).outgoingConnection(target.host, target.port)


### PR DESCRIPTION
The cloud deployment requires high customization on event streams.
The usage of config file requires "config distribution". It makes
either complicated deployment or requires customer specific artifacts.

The event source configuration is defined as URI and environment variable.
You can defined it during the container deployment via -e flag.